### PR TITLE
Changing locators to work with classes

### DIFF
--- a/src/page/AddressStep.page.ts
+++ b/src/page/AddressStep.page.ts
@@ -2,7 +2,7 @@ import { $, ElementFinder, promise } from 'protractor';
 
 export class AddressStepPage {
   private get proceedToCheckoutButton(): ElementFinder {
-    return $('#center_column > form > p > button > span');
+    return $('button[name="processAddress"]');
   }
 
   public proceedToCheckout(): promise.Promise<void> {

--- a/src/page/MenuContent.page.ts
+++ b/src/page/MenuContent.page.ts
@@ -2,7 +2,7 @@ import { $, ElementFinder, promise } from 'protractor';
 
 export class MenuContentPage {
   private get tShirtMenu(): ElementFinder {
-    return $('#block_top_menu > ul > li:nth-child(3) > a');
+    return $('.sf-menu > li:nth-child(3) > a');
   }
 
   public goToTShirtMenu(): promise.Promise<void> {

--- a/src/page/MenuContent.page.ts
+++ b/src/page/MenuContent.page.ts
@@ -2,7 +2,7 @@ import { $, ElementFinder, promise } from 'protractor';
 
 export class MenuContentPage {
   private get tShirtMenu(): ElementFinder {
-    return $('.sf-menu > li:nth-child(3) > a');
+    return $('.sf-menu:last-child');
   }
 
   public goToTShirtMenu(): promise.Promise<void> {

--- a/src/page/PaymentStep.page.ts
+++ b/src/page/PaymentStep.page.ts
@@ -2,7 +2,7 @@ import { $, ElementFinder, promise } from 'protractor';
 
 export class PaymentStepPage {
   private get paymentMethodOption(): ElementFinder {
-    return $('#HOOK_PAYMENT > div:nth-child(1) > div > p > a');
+    return $('.bankwire');
   }
   
   public selectPaymentMethod(): promise.Promise<void> {

--- a/src/page/ProductAddedModal.page.ts
+++ b/src/page/ProductAddedModal.page.ts
@@ -3,7 +3,7 @@ import { $, ElementFinder, ExpectedConditions, browser } from 'protractor';
 export class ProductAddedModalPage {
 
   private get proceedToCheckoutButton(): ElementFinder {
-    return $('[style*="display: block;"] .button-container > a');
+    return $('a[title="Proceed to checkout"]');
   }
 
   public async proceedToCheckout(): Promise<void> {

--- a/src/page/ProductDetail.page.ts
+++ b/src/page/ProductDetail.page.ts
@@ -2,7 +2,7 @@ import { $, ElementFinder, promise } from 'protractor';
 
 export class ProductDetailPage {
   private get addToCartButton(): ElementFinder {
-    return $('#add_to_cart > button > span');
+    return $('button.exclusive');
   }
 
   public addToCart(): promise.Promise<void> {

--- a/src/page/ProductList.page.ts
+++ b/src/page/ProductList.page.ts
@@ -2,7 +2,7 @@ import { $, ElementFinder, promise } from 'protractor';
 
 export class ProductListPage {
   private get tShirtImage(): ElementFinder {
-    return $('ul.product_list > li > div > div.left-block > div > a.product_img_link > img');
+    return $('.product_img_link');
   }
 
   public goToTShirtList(): promise.Promise<void> {

--- a/src/page/ProductList.page.ts
+++ b/src/page/ProductList.page.ts
@@ -2,7 +2,7 @@ import { $, ElementFinder, promise } from 'protractor';
 
 export class ProductListPage {
   private get tShirtImage(): ElementFinder {
-    return $('#center_column > ul > li > div > div.left-block > div > a.product_img_link > img');
+    return $('ul.product_list > li > div > div.left-block > div > a.product_img_link > img');
   }
 
   public goToTShirtList(): promise.Promise<void> {

--- a/src/page/ShippingStep.page.ts
+++ b/src/page/ShippingStep.page.ts
@@ -6,7 +6,7 @@ export class ShippingStepPage {
   }
   
   private get checkoutButton(): ElementFinder {
-    return $('#form > p > button > span');
+    return $('.cart_navigation > button');
   }
 
   public async proceedToCheckout(): Promise<void> {


### PR DESCRIPTION
Hago pull request con solo 2 locators cambiados para expresar la idea que tengo para cambiarlos todos.

Veo que los locators ya usan el id mas profundo posible antes de pasar a usar el parent selector (>).

Mi idea es buscar una clase unica en todo el DOM que este lo mas cerca posible del elemento que necesito y luego usar algun otro [selector](https://www.w3schools.com/cssref/css_selectors.asp) para obtener el elemento.
